### PR TITLE
Option to read all bytes in stream

### DIFF
--- a/_examples/webview/qtalk.bundle.js
+++ b/_examples/webview/qtalk.bundle.js
@@ -597,6 +597,12 @@ System.register("mux/channel", ["mux/util", "mux/codec/index", "mux/internal"], 
                                 resolve(undefined);
                                 return;
                             }
+                            if (!len && this.readBuf.length > 0) {
+                                let data = this.readBuf;
+                                this.readBuf = this.readBuf.slice(this.readBuf.length);
+                                resolve(data);
+                                return;
+                            }
                             if (this.readBuf.length >= len) {
                                 let data = this.readBuf.slice(0, len);
                                 this.readBuf = this.readBuf.slice(len);
@@ -784,6 +790,12 @@ System.register("mux/transport/websocket", ["mux/internal", "mux/util"], functio
                         var tryRead = () => {
                             if (this.isClosed) {
                                 resolve(undefined);
+                                return;
+                            }
+                            if (!len && this.buf.length > 0) {
+                                let data = this.buf;
+                                this.buf = this.buf.slice(this.buf.length);
+                                resolve(data);
                                 return;
                             }
                             if (this.buf.length >= len) {

--- a/javascript/mux/channel.ts
+++ b/javascript/mux/channel.ts
@@ -48,6 +48,12 @@ export class Channel {
                     resolve(undefined);
                     return;
                 }
+				if (!len && this.readBuf.length > 0) {
+                    let data = this.readBuf;
+                    this.readBuf = this.readBuf.slice(this.readBuf.length);
+                    resolve(data);
+					return;
+				}
                 if (this.readBuf.length >= len) {
                     let data = this.readBuf.slice(0, len);
 					this.readBuf = this.readBuf.slice(len);

--- a/javascript/mux/transport/websocket.ts
+++ b/javascript/mux/transport/websocket.ts
@@ -43,8 +43,14 @@ export class Conn implements api.IConn {
     read(len: number): Promise<Uint8Array|undefined> {
         return new Promise((resolve) => {
             var tryRead = () => {
-                if (this.isClosed) {
+                if (this.isClosed) {    
                     resolve(undefined);
+                    return;
+                }
+                if (!len && this.buf.length > 0) {
+                    let data = this.buf;
+                    this.buf = this.buf.slice(this.buf.length);
+                    resolve(data);
                     return;
                 }
                 if (this.buf.length >= len) {

--- a/javascript/qtalk.bundle.js
+++ b/javascript/qtalk.bundle.js
@@ -597,6 +597,12 @@ System.register("mux/channel", ["mux/util", "mux/codec/index", "mux/internal"], 
                                 resolve(undefined);
                                 return;
                             }
+                            if (!len && this.readBuf.length > 0) {
+                                let data = this.readBuf;
+                                this.readBuf = this.readBuf.slice(this.readBuf.length);
+                                resolve(data);
+                                return;
+                            }
                             if (this.readBuf.length >= len) {
                                 let data = this.readBuf.slice(0, len);
                                 this.readBuf = this.readBuf.slice(len);
@@ -784,6 +790,12 @@ System.register("mux/transport/websocket", ["mux/internal", "mux/util"], functio
                         var tryRead = () => {
                             if (this.isClosed) {
                                 resolve(undefined);
+                                return;
+                            }
+                            if (!len && this.buf.length > 0) {
+                                let data = this.buf;
+                                this.buf = this.buf.slice(this.buf.length);
+                                resolve(data);
                                 return;
                             }
                             if (this.buf.length >= len) {


### PR DESCRIPTION
Passing falsy value into channel or websocket `read` will retrieve all bytes
